### PR TITLE
Update supabase cli version in pg_tests actions

### DIFF
--- a/.github/workflows/pg_tests.yml
+++ b/.github/workflows/pg_tests.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: supabase/setup-cli@v1
         with:
-          version: 1.50.11
+          version: latest
       - name: Supabase Start
         run: supabase start
       - name: Run Tests


### PR DESCRIPTION
I hit the same issue running the pg_tests actions as mentioned in #46 - this just updates the actions file to use the `latest` version of the supabase cli