### PR TITLE
Update stripe-function-handler.ts

### DIFF
--- a/supabase/functions/deno-packages/billing-functions/src/providers/stripe/stripe-function-handler.ts
+++ b/supabase/functions/deno-packages/billing-functions/src/providers/stripe/stripe-function-handler.ts
@@ -25,8 +25,6 @@ export function stripeFunctionHandler({
                                    accountId,
                                    customerId,
                                    billingEmail,
-                                   defaultTrialDays,
-                                   defaultPlanId,
                                    subscriptionId,
                                }) {
             const customer = await findOrCreateCustomer(stripeClient, {


### PR DESCRIPTION
Creating default subscription isn't working since blank defaultPlanId and defaultTrialDays are passed into the getBillingStatus function instead of using the ones passed into the stripeFunctionHandler. Related to #64