### PR TITLE
Make automatic create of personal accounts configurable

### DIFF
--- a/supabase/migrations/20240414161707_basejump-setup.sql
+++ b/supabase/migrations/20240414161707_basejump-setup.sql
@@ -64,12 +64,13 @@ CREATE TABLE IF NOT EXISTS basejump.config
     enable_team_accounts            boolean default true,
     enable_personal_account_billing boolean default true,
     enable_team_account_billing     boolean default true,
+    enable_automatic_personal_team  boolean default true, -- In some setups you might not want to automatically create a personal space. In this case set this value to false.
     billing_provider                text    default 'stripe'
 );
 
 -- create config row
-INSERT INTO basejump.config (enable_team_accounts, enable_personal_account_billing, enable_team_account_billing)
-VALUES (true, true, true);
+INSERT INTO basejump.config (enable_team_accounts, enable_personal_account_billing, enable_team_account_billing, enable_automatic_personal_team)
+VALUES (true, true, true, false);
 
 -- enable select on the config table
 GRANT SELECT ON basejump.config TO authenticated, service_role;

--- a/supabase/migrations/20240414161947_basejump-accounts.sql
+++ b/supabase/migrations/20240414161947_basejump-accounts.sql
@@ -209,21 +209,25 @@ declare
     first_account_id    uuid;
     generated_user_name text;
 begin
+    -- Check the condition
+    if basejump.is_set('enable_automatic_personal_team') then
 
-    -- first we setup the user profile
-    -- TODO: see if we can get the user's name from the auth.users table once we learn how oauth works
-    if new.email IS NOT NULL then
-        generated_user_name := split_part(new.email, '@', 1);
+        -- first we setup the user profile
+        -- TODO: see if we can get the user's name from the auth.users table once we learn how oauth works
+        if new.email IS NOT NULL then
+            generated_user_name := split_part(new.email, '@', 1);
+        end if;
+        -- create the new users's personal account
+        insert into basejump.accounts (name, primary_owner_user_id, personal_account, id)
+        values (generated_user_name, NEW.id, true, NEW.id)
+        returning id into first_account_id;
+
+        -- add them to the account_user table so they can act on it
+        insert into basejump.account_user (account_id, user_id, account_role)
+        values (first_account_id, NEW.id, 'owner');
+
+        return NEW;
     end if;
-    -- create the new users's personal account
-    insert into basejump.accounts (name, primary_owner_user_id, personal_account, id)
-    values (generated_user_name, NEW.id, true, NEW.id)
-    returning id into first_account_id;
-
-    -- add them to the account_user table so they can act on it
-    insert into basejump.account_user (account_id, user_id, account_role)
-    values (first_account_id, NEW.id, 'owner');
-
     return NEW;
 end;
 $$;

--- a/supabase/tests/database/01-basejump-schema-tests.sql
+++ b/supabase/tests/database/01-basejump-schema-tests.sql
@@ -1,5 +1,5 @@
 BEGIN;
-create extension "basejump-supabase_test_helpers" version '0.0.6';
+create extension if not exists "basejump-supabase_test_helpers" version '0.0.6';
 
 select plan(20);
 
@@ -15,7 +15,7 @@ select has_table('basejump', 'billing_subscriptions', 'Basejump billing_subscrip
 select tests.rls_enabled('basejump');
 
 select columns_are('basejump', 'config',
-                   Array ['enable_team_accounts', 'enable_personal_account_billing', 'enable_team_account_billing', 'billing_provider'],
+                   Array ['enable_team_accounts', 'enable_personal_account_billing', 'enable_team_account_billing', 'enable_automatic_personal_team', 'billing_provider'],
                    'Basejump config table should have the correct columns');
 
 

--- a/supabase/tests/database/02-no-personal-accounts.sql
+++ b/supabase/tests/database/02-no-personal-accounts.sql
@@ -1,0 +1,39 @@
+BEGIN;
+create extension if not exists "basejump-supabase_test_helpers" version '0.0.6';
+
+select plan(2);
+
+-- make sure we're not setup for automatic personal team account creation
+update basejump.config
+set enable_automatic_personal_team = false;
+
+--- we insert a user into auth.users and return the id into user_id to use
+
+select tests.create_supabase_user('test1', 'test1@test.com');
+select tests.create_supabase_user('test2');
+
+select tests.create_supabase_user('test3', 'test3@test.com');
+select tests.create_supabase_user('test4', 'test4@test.com');
+
+
+------------
+--- Primary Owner
+------------
+select tests.authenticate_as('test1');
+
+-- should not create any personal account automatically
+SELECT is_empty(
+               $$ select name from basejump.accounts limit 1 $$,
+               'Inserting a user should create a personal account when personal accounts are enabled'
+           );
+
+-- should have not created accounts that are personal
+SELECT is_empty(
+                $$ select name from basejump.accounts where personal_account = true limit 1 $$,
+               'Should not have created personal accounts'
+           );
+
+SELECT *
+FROM finish();
+
+ROLLBACK;

--- a/supabase/tests/database/02-personal-accounts.sql
+++ b/supabase/tests/database/02-personal-accounts.sql
@@ -1,7 +1,11 @@
 BEGIN;
-create extension "basejump-supabase_test_helpers" version '0.0.6';
+create extension if not exists "basejump-supabase_test_helpers" version '0.0.6';
 
 select plan(15);
+
+-- make sure we're setup for automatic personal team account creation
+update basejump.config
+set enable_automatic_personal_team = true;
 
 --- we insert a user into auth.users and return the id into user_id to use
 

--- a/supabase/tests/database/04-team-accounts.sql
+++ b/supabase/tests/database/04-team-accounts.sql
@@ -1,5 +1,5 @@
 BEGIN;
-create extension "basejump-supabase_test_helpers" version '0.0.6';
+create extension if not exists "basejump-supabase_test_helpers" version '0.0.6';
 
 select plan(34);
 

--- a/supabase/tests/database/05-team-accounts-disabled.sql
+++ b/supabase/tests/database/05-team-accounts-disabled.sql
@@ -1,5 +1,5 @@
 BEGIN;
-create extension "basejump-supabase_test_helpers" version '0.0.6';
+create extension if not exists "basejump-supabase_test_helpers" version '0.0.6';
 
 select plan(1);
 

--- a/supabase/tests/database/06-invitations.sql
+++ b/supabase/tests/database/06-invitations.sql
@@ -1,7 +1,7 @@
 -- the main testing for invitations on accounts is in the team_accounts tests
 -- this batch is to let us test the more complicated behaviors such as one_time, 24_hour, multiple use, etc...accounts
 BEGIN;
-create extension "basejump-supabase_test_helpers" version '0.0.6';
+create extension if not exists "basejump-supabase_test_helpers" version '0.0.6';
 
 select plan(35);
 

--- a/supabase/tests/database/07-inviting-team-member.sql
+++ b/supabase/tests/database/07-inviting-team-member.sql
@@ -1,11 +1,14 @@
 BEGIN;
-create extension "basejump-supabase_test_helpers" version '0.0.6';
+create extension if not exists "basejump-supabase_test_helpers" version '0.0.6';
 
 select plan(10);
 
 -- make sure we're setup for enabling personal accounts
 update basejump.config
-set enable_team_accounts = true;
+set enable_team_accounts = true,
+    -- make sure we're setup for automatic personal team account creation
+    enable_automatic_personal_team = true;
+ 
 
 --- Create the users we need for testing
 select tests.create_supabase_user('test1');

--- a/supabase/tests/database/08-inviting-team-owner.sql
+++ b/supabase/tests/database/08-inviting-team-owner.sql
@@ -1,5 +1,5 @@
 BEGIN;
-create extension "basejump-supabase_test_helpers" version '0.0.6';
+create extension if not exists "basejump-supabase_test_helpers" version '0.0.6';
 
 select plan(9);
 

--- a/supabase/tests/database/09-removing-team-members.sql
+++ b/supabase/tests/database/09-removing-team-members.sql
@@ -1,5 +1,5 @@
 BEGIN;
-create extension "basejump-supabase_test_helpers" version '0.0.6';
+create extension if not exists "basejump-supabase_test_helpers" version '0.0.6';
 
 select plan(6);
 

--- a/supabase/tests/database/10-account-roles.sql
+++ b/supabase/tests/database/10-account-roles.sql
@@ -1,5 +1,5 @@
 BEGIN;
-create extension "basejump-supabase_test_helpers" version '0.0.6';
+create extension if not exists "basejump-supabase_test_helpers" version '0.0.6';
 
 select plan(17);
 -- make sure we're setup for enabling personal accounts

--- a/supabase/tests/database/11-public-account-functions.sql
+++ b/supabase/tests/database/11-public-account-functions.sql
@@ -1,11 +1,13 @@
 BEGIN;
-create extension "basejump-supabase_test_helpers" version '0.0.6';
+create extension if not exists "basejump-supabase_test_helpers" version '0.0.6';
 
 select plan(29);
 
 -- make sure we're setup for the test correctly
-update basejump.config
-set enable_team_accounts = true;
+update basejump.config 
+set enable_team_accounts = true,
+    -- make sure we're setup for automatic personal team account creation
+    enable_automatic_personal_team = true;
 
 --- we insert a user into auth.users and return the id into user_id to use
 select tests.create_supabase_user('test1');

--- a/supabase/tests/database/12-created-by-tracking.sql
+++ b/supabase/tests/database/12-created-by-tracking.sql
@@ -1,5 +1,5 @@
 BEGIN;
-create extension "basejump-supabase_test_helpers" version '0.0.6';
+create extension if not exists "basejump-supabase_test_helpers" version '0.0.6';
 
 select plan(5);
 

--- a/supabase/tests/database/14-public-billing-functions.sql
+++ b/supabase/tests/database/14-public-billing-functions.sql
@@ -1,5 +1,5 @@
 BEGIN;
-create extension "basejump-supabase_test_helpers" version '0.0.6';
+create extension if not exists "basejump-supabase_test_helpers" version '0.0.6';
 
 update basejump.config
 set enable_team_account_billing     = TRUE,

--- a/supabase/tests/database/15-billing-disabled-functions.sql
+++ b/supabase/tests/database/15-billing-disabled-functions.sql
@@ -1,9 +1,11 @@
 BEGIN;
-create extension "basejump-supabase_test_helpers" version '0.0.6';
+create extension if not exists "basejump-supabase_test_helpers" version '0.0.6';
 
 update basejump.config
 set enable_personal_account_billing = FALSE,
-    enable_team_account_billing     = FALSE;
+    enable_team_account_billing     = FALSE,
+    -- make sure we're setup for automatic personal team account creation
+    enable_automatic_personal_team = true;
 
 select plan(6);
 


### PR DESCRIPTION
For my current projects I have to remove the feature to automatically create a "personal" space on user creation.

This merge request contains mainly:
1. an extra boolean field for the global config to disable this feature. 
2. Also the tests crash on my end, this is why I added a **if not exists** check in `if create extension if not exists "basejump-supabase_test_helpers" version '0.0.6';`
3. I added a new test file to check the new configuration.


Let me know what you think! :-)